### PR TITLE
Tested in notprod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lightweight-kube-etl",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "lightweight-kube-etl",
   "version": "2.3.0",
-  "description": "",
+  "description": "extracts, transforms and loads data into entitysearch",
   "main": "index.js",
   "scripts": {
     "start": "node index",
     "test": "KUBE_SERVICE_ACCOUNT_TOKEN=MOCK_TOKEN BUCKET=test.bucket jest --coverage",
     "test-watch": "KUBE_SERVICE_ACCOUNT_TOKEN=MOCK_TOKEN BUCKET=test.bucket jest --watch",
-    "precommit": "pretty-quick --staged"
+    "precommit": "pretty-quick --staged && npm test"
   },
   "author": "dacc@ukhomeoffice",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightweight-kube-etl",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "extracts, transforms and loads data into entitysearch",
   "main": "index.js",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -79,6 +79,13 @@ const getPodStatus = R.compose(
   R.pathOr([], ['status', 'containerStatuses'])
 )
 
+const getPodStartedAt = R.compose(
+  R.pathOr(false, ['state', 'running', 'startedAt']),
+  R.head,
+  R.filter(R.propEq('name', 'build')),
+  R.pathOr([], ['status', 'containerStatuses'])  
+)
+
 class Times {
   constructor () {
     this.neoStart = null;
@@ -122,5 +129,6 @@ module.exports = {
   getIngestFiles,
   getJobDuration,
   getPodStatus,
+  getPodStartedAt,
   Times
 }

--- a/src/helpers.spec.js
+++ b/src/helpers.spec.js
@@ -11,6 +11,7 @@ const {
   getIngestFiles,
   getJobDuration,
   getPodStatus,
+  getPodStartedAt,
   Times
 } = require('./helpers');
 
@@ -69,7 +70,7 @@ const pod_status_not_ready = {
     "containerStatuses": [
       {
         "name": "build",
-        "ready": false,
+        "ready": true,
         "restartCount": 0,
         "state": {
             "running": {
@@ -297,7 +298,34 @@ describe('Times', () => {
     expect(timer.getElasticEnd()).toBe(null);
     expect(timer.getIngestFiles()).toBe(null);
   })
-})
+});
+
+describe('getPodStartedAt', () => {
+  it('should grab the startedAt time', () => {
+    expect(getPodStartedAt(pod_status_not_ready)).toBe("2018-10-09T10:10:00Z");
+  });
+
+  it('should handle rolling state', () => {
+    const rolling_update = {
+      "status": {
+        "containerStatuses": [
+          {
+            "name": "build",
+            "ready": true,
+            "restartCount": 0,
+            "state": {
+                "terminated": {
+                  "containerID": "docker://9f4698514ea"
+                }
+            }
+          }
+        ]
+      }
+    };
+
+    expect(getPodStartedAt(rolling_update)).toBe(false);
+  });
+});
 
 module.exports = {
   complete_job,

--- a/src/ingestor.js
+++ b/src/ingestor.js
@@ -184,7 +184,7 @@ function checkRollingStatus (podName, jobStartTime, podReady) {
     } else {
       const statusOk = getPodStatus(JSON.parse(stdout));
       const startedAt = getPodStartedAt(JSON.parse(stdout));
-      const isNew = moment(startedAt).isAfter(jobStartTime);
+      const isNew = startedAt ? moment(startedAt).isAfter(jobStartTime) : startedAt;
       
       statusOk && isNew
         ? podReady() 
@@ -329,7 +329,7 @@ function waitForCompletion (err, {ingestType, ingestName}, timer, start) {
           ingest: ingestName,
           type: ingestType,
           load_date: new Date(),
-          readable_date: moment(new Date()).format('dd MMM yyyy HH:mm'),
+          readable_date: moment(new Date()).format('ddd MMM YYYY HH:mm'),
           neo_job_duration: getJobDuration(timer.getNeoStart(), timer.getNeoEnd()),
           elastic_job_duration: getJobDuration(timer.getElasticStart(), timer.getElasticEnd()),
           total_job_duration: getJobDuration(timer.getNeoStart(), ingestEndTime)

--- a/src/ingestor.spec.js
+++ b/src/ingestor.spec.js
@@ -352,7 +352,7 @@ describe('Kubectl - waitForCompletion', () => {
       "ingest": "1538055555",
       "type": "incremental",
       "load_date": 1540394977882,
-      "readable_date": "Oct 24th 16:29",
+      "readable_date": "Fri Oct 24th 04:29pm",
       "neo_job_duration": "2h:15mins",
       "elastic_job_duration": "1h:05mins",
       "total_job_duration": "2h:29mins"


### PR DESCRIPTION
Here is change-set for an updated version of the ETL (2.4.0)

* Tests
* Deltas in series

```
Oct 26th 10:09: neo4j-delta-1538055249 triggered :)
Oct 26th 10:16: neo4j-delta-1538055249 pods ready
Oct 26th 10:16: elastic-delta-1538055249 triggered :)
Oct 26th 10:20: elastic-delta-1538055249 pods ready
```

In the above logging you can see the `elastic-delta` is not triggered until the neo pods are ready. I had to add another check for both the readiness of the pod and it's startedAt time.

```
function checkRollingStatus (podName, jobStartTime, podReady) {
  exec(`kubectl ${R.join(' ', baseArgs)} get pods ${podName} -o json`, (err, stdout, stderr) => {
    if (err || stderr) {
      setTimeout(() => checkRollingStatus(podName, jobStartTime, podReady), pollingInterval);
    } else {
      const statusOk = getPodStatus(JSON.parse(stdout));
      const startedAt = getPodStartedAt(JSON.parse(stdout));
      const isNew = startedAt ? moment(startedAt).isAfter(jobStartTime) : startedAt;
      
      statusOk && isNew
        ? podReady() 
        : setTimeout(() => checkRollingStatus(podName, jobStartTime, podReady), pollingInterval);
    }
  });  
}
```

Apologies for the previous commit to master. I had a rebase **nightmare** and decided to push to master as I was getting into a mess.